### PR TITLE
Package type changed to `wordpress-theme`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,6 @@
 {
     "name": "grottopress/jentil",
+    "type": "wordpress-theme",
     "description": "Jentil is a modern framework for rapid WordPress theme development",
     "license": "MIT",
     "homepage": "https://jentil.grottopress.com",


### PR DESCRIPTION
This allows the `composer-installers` plugin to install it into the correct directory.